### PR TITLE
Fix webhook dependency for Telegram bot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 requests
 python-dotenv
-python-telegram-bot>=20.0
+python-telegram-bot[webhooks]>=20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests
-python-dotenv
-python-telegram-bot[webhooks]>=20.0
+requests==2.32.5
+python-dotenv==1.2.2
+python-telegram-bot[webhooks]==22.7


### PR DESCRIPTION
## Summary
- Install `python-telegram-bot[webhooks]` instead of `python-telegram-bot` — the `[webhooks]` extra is required for `run_webhook()` support

## Test plan
- [ ] `pip install -r requirements.txt` installs webhook dependencies
- [ ] `python coding_agent.py --serve` starts the webhook server without `RuntimeError`

https://claude.ai/code/session_01APqZbpXM49FsKdz8hmGNo2