### PR TITLE
Add long-running task support and Telegram progress reporting

### DIFF
--- a/coding_agent.py
+++ b/coding_agent.py
@@ -185,7 +185,8 @@ def agent_loop(user_input, conversation_history, api_key, docker_manager=None,
     STATUS_COMPLETE, STATUS_MAX_ROUNDS, or STATUS_ERROR.
     """
     messages = build_messages(conversation_history, user_input, docker_manager)
-    effective_max = max_rounds or MAX_TOOL_ROUNDS
+    effective_max = MAX_TOOL_ROUNDS if max_rounds is None else max_rounds
+    assistant_msg = {}
 
     for round_num in range(effective_max):
         print("\nAssistant: " if round_num == 0 else "", end="", flush=True, file=sys.stderr)

--- a/coding_agent.py
+++ b/coding_agent.py
@@ -16,7 +16,11 @@ load_dotenv()
 
 INVOKE_URL = "https://integrate.api.nvidia.com/v1/chat/completions"
 MODEL = "moonshotai/kimi-k2.5"
-MAX_TOOL_ROUNDS = 15
+MAX_TOOL_ROUNDS = 50
+
+STATUS_COMPLETE = "complete"
+STATUS_MAX_ROUNDS = "max_rounds"
+STATUS_ERROR = "error"
 
 SYSTEM_PROMPT = """\
 You are an expert coding agent. All file operations execute inside a Docker sandbox \
@@ -39,6 +43,10 @@ If a command or build fails because of a missing OS package, library, or runtime
 2. Add the missing package to the apt-get install line (or add new install commands).
 3. Call rebuild_container to rebuild the sandbox with the updated Dockerfile.
 4. Retry the failed operation.
+
+You have plenty of tool rounds available. Work through the entire task methodically — \
+explore, implement, verify, and fix issues until the task is truly complete. \
+If you encounter errors, debug and retry rather than giving up.
 
 Use the tools provided to complete the user's request. Be precise with file paths \
 and edits. Prefer patch_file over write_file when modifying existing files.\
@@ -169,25 +177,31 @@ def execute_tool(name, arguments_str):
     return handler(args)
 
 
-def agent_loop(user_input, conversation_history, api_key, docker_manager=None):
-    """Run the agent loop: call the model, execute tools, repeat until done."""
-    messages = build_messages(conversation_history, user_input, docker_manager)
+def agent_loop(user_input, conversation_history, api_key, docker_manager=None,
+               max_rounds=None, progress_callback=None):
+    """Run the agent loop: call the model, execute tools, repeat until done.
 
-    for round_num in range(MAX_TOOL_ROUNDS):
+    Returns (reply_text, status) where status is one of
+    STATUS_COMPLETE, STATUS_MAX_ROUNDS, or STATUS_ERROR.
+    """
+    messages = build_messages(conversation_history, user_input, docker_manager)
+    effective_max = max_rounds or MAX_TOOL_ROUNDS
+
+    for round_num in range(effective_max):
         print("\nAssistant: " if round_num == 0 else "", end="", flush=True, file=sys.stderr)
 
         try:
             assistant_msg = call_nvidia_api(messages, api_key, stream=True)
         except requests.exceptions.HTTPError as e:
             print(f"\nAPI error: {e}", file=sys.stderr)
-            return None
+            return None, STATUS_ERROR
 
         messages.append(assistant_msg)
 
         # If no tool calls, the agent is done
         tool_calls = assistant_msg.get("tool_calls")
         if not tool_calls:
-            return assistant_msg.get("content", "")
+            return assistant_msg.get("content", ""), STATUS_COMPLETE
 
         # Execute each tool call and add results
         print("\n[Tool calls]", file=sys.stderr)
@@ -206,10 +220,15 @@ def agent_loop(user_input, conversation_history, api_key, docker_manager=None):
                 "content": result,
             })
 
+        # Report progress after tool execution
+        if progress_callback:
+            tool_names = [tc["function"]["name"] for tc in tool_calls]
+            progress_callback(round_num + 1, effective_max, tool_names)
+
         print(file=sys.stderr)  # spacer before next model response
 
     print("\n[Reached maximum tool rounds]", file=sys.stderr)
-    return assistant_msg.get("content", "")
+    return assistant_msg.get("content", ""), STATUS_MAX_ROUNDS
 
 
 def main():
@@ -255,7 +274,10 @@ def main():
                 print("Conversation cleared.\n", file=sys.stderr)
                 continue
 
-            reply = agent_loop(user_input, conversation_history, api_key, docker)
+            reply, status = agent_loop(user_input, conversation_history, api_key, docker)
+
+            if status == STATUS_MAX_ROUNDS:
+                print("[Note: reached maximum tool rounds, response may be incomplete]", file=sys.stderr)
 
             if reply is not None:
                 conversation_history.append({"role": "user", "content": user_input})

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -9,12 +9,13 @@ from collections import defaultdict
 from telegram import Update
 from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters
 
-from coding_agent import agent_loop
+from coding_agent import agent_loop, STATUS_COMPLETE, STATUS_MAX_ROUNDS, STATUS_ERROR
 
 logger = logging.getLogger(__name__)
 
 TELEGRAM_MAX_MESSAGE_LENGTH = 4096
 WEBHOOK_PORT = int(os.getenv("WEBHOOK_PORT", "21031"))
+PROGRESS_REPORT_INTERVAL = 3  # send a progress update every N tool rounds
 
 # Per-chat conversation history: chat_id -> list of message dicts
 _chat_histories: dict[int, list] = {}
@@ -57,6 +58,33 @@ async def handle_clear(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
     await update.message.reply_text("Conversation cleared.")
 
 
+def make_progress_callback(chat, loop):
+    """Return a callback that sends progress updates to a Telegram chat.
+
+    The callback runs in the agent_loop thread and schedules sends on the
+    bot's event loop via run_coroutine_threadsafe.
+    """
+    last_reported = [0]
+
+    def callback(round_num, max_rounds, tool_names):
+        if round_num - last_reported[0] < PROGRESS_REPORT_INTERVAL:
+            return
+        last_reported[0] = round_num
+
+        tools_str = ", ".join(tool_names)
+        text = f"Round {round_num}/{max_rounds}: {tools_str}"
+
+        future = asyncio.run_coroutine_threadsafe(
+            chat.send_message(text), loop
+        )
+        try:
+            future.result(timeout=10)
+        except Exception:
+            pass  # progress reporting is best-effort
+
+    return callback
+
+
 async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle incoming text messages."""
     chat_id = update.effective_chat.id
@@ -74,16 +102,28 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
         # Send typing indicator
         await update.effective_chat.send_action("typing")
 
+        # Build progress callback for Telegram updates
+        loop = asyncio.get_running_loop()
+        progress_cb = make_progress_callback(update.effective_chat, loop)
+
         # Run the blocking agent_loop in a thread
         try:
-            reply = await asyncio.to_thread(agent_loop, user_text, history, api_key)
+            reply, status = await asyncio.to_thread(
+                agent_loop, user_text, history, api_key,
+                progress_callback=progress_cb,
+            )
         except Exception as e:
             logger.error(f"Error in agent_loop for chat {chat_id}: {e}", exc_info=True)
             reply = None
+            status = STATUS_ERROR
 
         if reply is None:
             await update.message.reply_text("Sorry, an error occurred while processing your request.")
             return
+
+        # Append status indicator for incomplete results
+        if status == STATUS_MAX_ROUNDS:
+            reply += "\n\n-- Reached maximum tool rounds. The task may be incomplete."
 
         # Update conversation history
         history.append({"role": "user", "content": user_text})

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -79,8 +79,8 @@ def make_progress_callback(chat, loop):
         )
         try:
             future.result(timeout=10)
-        except Exception:
-            pass  # progress reporting is best-effort
+        except Exception as e:
+            logger.warning(f"Failed to send progress update: {e}")
 
     return callback
 


### PR DESCRIPTION
- Increase MAX_TOOL_ROUNDS from 15 to 50 for complex multi-step tasks
- Add progress_callback parameter to agent_loop, invoked after each tool-execution round with (round_num, max_rounds, tool_names)
- Return (reply, status) tuple from agent_loop instead of bare string, with STATUS_COMPLETE / STATUS_MAX_ROUNDS / STATUS_ERROR
- In Telegram mode, send progress updates every 3 rounds via make_progress_callback using run_coroutine_threadsafe
- Append status suffix to Telegram reply when max rounds are hit
- Add encouraging system prompt line to avoid premature task abandonment

https://claude.ai/code/session_01AMuKLCSuxZ8x1gixHH5B7m