### PR TITLE
Fix Dockerfile path resolution and add batch file tools with API retry

### DIFF
--- a/coding_agent.py
+++ b/coding_agent.py
@@ -199,23 +199,24 @@ def agent_loop(user_input, conversation_history, api_key, docker_manager=None,
             try:
                 assistant_msg = call_nvidia_api(messages, api_key, stream=True)
                 break
-            except requests.exceptions.HTTPError as e:
-                status_code = e.response.status_code if e.response is not None else 0
-                if (status_code == 429 or status_code >= 500) and attempt < max_retries:
+            except (requests.exceptions.HTTPError, requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
+                is_http_error = isinstance(e, requests.exceptions.HTTPError)
+                status_code = e.response.status_code if is_http_error and e.response is not None else 0
+
+                is_retryable = (
+                    (is_http_error and (status_code == 429 or status_code >= 500)) or
+                    isinstance(e, (requests.exceptions.ConnectionError, requests.exceptions.Timeout))
+                )
+
+                if is_retryable and attempt < max_retries:
                     wait = 2 ** (attempt + 1)
-                    print(f"\nAPI error ({status_code}), retrying in {wait}s... (attempt {attempt + 1}/{max_retries})", file=sys.stderr)
+                    error_type = status_code if is_http_error else "Connection"
+                    print(f"\nAPI error ({error_type}), retrying in {wait}s... (attempt {attempt + 1}/{max_retries})", file=sys.stderr)
                     time.sleep(wait)
-                    continue
-                print(f"\nAPI error: {e}", file=sys.stderr)
-                return None, STATUS_ERROR
-            except (requests.exceptions.ConnectionError, requests.exceptions.Timeout) as e:
-                if attempt < max_retries:
-                    wait = 2 ** (attempt + 1)
-                    print(f"\nConnection error, retrying in {wait}s... (attempt {attempt + 1}/{max_retries})", file=sys.stderr)
-                    time.sleep(wait)
-                    continue
-                print(f"\nAPI error: {e}", file=sys.stderr)
-                return None, STATUS_ERROR
+                elif not is_retryable:
+                    print(f"\nAPI error: {e}", file=sys.stderr)
+                    return None, STATUS_ERROR
+                # else: is_retryable and it's the last attempt. Loop will finish.
         else:
             print(f"\nAPI error: max retries exceeded", file=sys.stderr)
             return None, STATUS_ERROR

--- a/tools.py
+++ b/tools.py
@@ -170,8 +170,11 @@ def multi_write_file(files: list[dict]) -> str:
     dm = _get_docker_manager()
     results = []
     for entry in files:
-        path = entry["path"]
-        content = entry["content"]
+        path = entry.get("path")
+        content = entry.get("content")
+        if path is None or content is None:
+            results.append({"error": "Each file entry must have 'path' and 'content' keys.", "entry_keys": list(entry.keys())})
+            continue
         dir_path = os.path.dirname(path)
         if dir_path:
             rc, _, stderr = dm.exec(["mkdir", "-p", dir_path])


### PR DESCRIPTION
- Add read_dockerfile/write_dockerfile tools that operate on the host filesystem
  instead of inside the container, fixing the self-improving Dockerfile workflow
- Add multi_read_file/multi_write_file tools to batch file operations and save
  tool call rounds
- Add exponential backoff retry (up to 4 attempts) for 429 and 5xx API errors

https://claude.ai/code/session_012fWUkCaWkadJ8PxVrVGqne