### PR TITLE
Use dedicated workspace folder instead of current directory

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,10 @@ TELEGRAM_BOT_TOKEN=your-telegram-bot-token
 TELEGRAM_WEBHOOK_URL=https://yourdomain.com/bot-webhook
 WEBHOOK_PORT=21031
 
+# Workspace directory for the agent's Docker sandbox (optional).
+# Defaults to ~/coding-guy-workspace if not set.
+WORKSPACE_DIR=/path/to/your/workspace
+
 # Git credentials (optional) — passed into the Docker sandbox
 # so the agent can push/pull/clone and make commits.
 GIT_TOKEN=your-git-token-here

--- a/coding_agent.py
+++ b/coding_agent.py
@@ -20,7 +20,9 @@ MODEL = "moonshotai/kimi-k2.5"
 MAX_TOOL_ROUNDS = 50
 
 # Dedicated workspace directory for the agent's Docker sandbox.
-DEFAULT_WORKSPACE = os.path.join(os.path.expanduser("~"), "coding-guy-workspace")
+DEFAULT_WORKSPACE = os.environ.get(
+    "WORKSPACE_DIR", os.path.join(os.path.expanduser("~"), "coding-guy-workspace")
+)
 
 STATUS_COMPLETE = "complete"
 STATUS_MAX_ROUNDS = "max_rounds"

--- a/coding_agent.py
+++ b/coding_agent.py
@@ -267,7 +267,7 @@ def main():
     parser.add_argument(
         "--workspace",
         default=DEFAULT_WORKSPACE,
-        help=f"Workspace directory for the agent sandbox (default: {DEFAULT_WORKSPACE})",
+        help="Workspace directory for the agent sandbox (default: %(default)s)",
     )
     args = parser.parse_args()
 

--- a/coding_agent.py
+++ b/coding_agent.py
@@ -19,6 +19,9 @@ INVOKE_URL = "https://integrate.api.nvidia.com/v1/chat/completions"
 MODEL = "moonshotai/kimi-k2.5"
 MAX_TOOL_ROUNDS = 50
 
+# Dedicated workspace directory for the agent's Docker sandbox.
+DEFAULT_WORKSPACE = os.path.join(os.path.expanduser("~"), "coding-guy-workspace")
+
 STATUS_COMPLETE = "complete"
 STATUS_MAX_ROUNDS = "max_rounds"
 STATUS_ERROR = "error"
@@ -259,13 +262,21 @@ def agent_loop(user_input, conversation_history, api_key, docker_manager=None,
 def main():
     parser = argparse.ArgumentParser(description="Coding agent powered by Nvidia API (Kimi K2.5)")
     parser.add_argument("--serve", action="store_true", help="Start Telegram bot webhook server")
+    parser.add_argument(
+        "--workspace",
+        default=DEFAULT_WORKSPACE,
+        help=f"Workspace directory for the agent sandbox (default: {DEFAULT_WORKSPACE})",
+    )
     args = parser.parse_args()
 
     api_key = get_api_key()
     conversation_history = []
 
-    # Initialize Docker sandbox
-    docker = DockerManager(work_dir=os.getcwd())
+    # Ensure the dedicated workspace directory exists.
+    os.makedirs(args.workspace, exist_ok=True)
+
+    # Initialize Docker sandbox with the dedicated workspace.
+    docker = DockerManager(work_dir=args.workspace)
     set_docker_manager(docker)
 
     if args.serve:


### PR DESCRIPTION
The agent now defaults to ~/coding-guy-workspace instead of os.getcwd(),
so the sandbox is isolated from wherever the script is launched. A new
--workspace CLI flag allows overriding the path.

https://claude.ai/code/session_01YQWBRpNY6T784TuCDdJcwk