### PR TITLE
Add SSH clone support with auto-detection and HTTPS fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,9 @@ WORKSPACE_DIR=/path/to/your/workspace
 GIT_TOKEN=your-git-token-here
 GIT_USER_NAME=your-name
 GIT_USER_EMAIL=your-email@example.com
+
+# SSH cloning support (automatic — no configuration needed).
+# When SSH_AUTH_SOCK is set, the agent forwards your SSH agent into the
+# container for git clone over SSH.  If ~/.ssh keys exist, they are
+# mounted read-only.  When SSH is unavailable, SSH URLs are automatically
+# rewritten to HTTPS using GIT_TOKEN above.

--- a/coding_agent.py
+++ b/coding_agent.py
@@ -56,6 +56,12 @@ You have plenty of tool rounds available. Work through the entire task methodica
 explore, implement, verify, and fix issues until the task is truly complete. \
 If you encounter errors, debug and retry rather than giving up.
 
+When cloning repositories:
+- Both SSH URLs (git@host:owner/repo.git) and HTTPS URLs work automatically.
+- If SSH is not configured, SSH URLs are transparently rewritten to HTTPS.
+- If cloning fails with an authentication error, suggest the user check their \
+GIT_TOKEN or SSH key configuration.
+
 Use the tools provided to complete the user's request. Be precise with file paths \
 and edits. Prefer patch_file over write_file when modifying existing files.\
 """
@@ -81,6 +87,14 @@ def build_messages(conversation_history, user_input, docker_manager=None):
             "is a missing package (e.g. git). Update the Dockerfile and call "
             "rebuild_container, then retry the failed configuration."
         )
+    if docker_manager:
+        mode = docker_manager.ssh_mode
+        if mode == "agent":
+            system += "\n\nSSH mode: agent. SSH agent is forwarded from the host — SSH cloning works natively."
+        elif mode == "keys":
+            system += "\n\nSSH mode: keys. SSH keys are mounted from the host — SSH cloning works natively."
+        else:
+            system += "\n\nSSH mode: none. SSH URLs are automatically converted to HTTPS with token auth."
     messages = [{"role": "system", "content": system}]
     messages.extend(conversation_history)
     messages.append({"role": "user", "content": user_input})

--- a/docker_manager.py
+++ b/docker_manager.py
@@ -165,13 +165,23 @@ class DockerManager:
 
         # When SSH is not available, rewrite SSH URLs to HTTPS using GIT_TOKEN.
         if self.ssh_mode == "none":
-            git_token = os.getenv("GIT_TOKEN")
-            if git_token:
-                self._configure_https_fallback(git_token)
+            self._try_configure_https_fallback()
+
+    def _try_configure_https_fallback(self) -> None:
+        """Configure HTTPS fallback if GIT_TOKEN is available."""
+        git_token = os.getenv("GIT_TOKEN")
+        if git_token:
+            self._configure_https_fallback(git_token)
 
     def _configure_https_fallback(self, git_token: str) -> None:
         """Set up git to rewrite SSH URLs to HTTPS and authenticate with a token."""
-        for host in ("github.com", "gitlab.com", "bitbucket.org"):
+        # Each provider requires a specific username for token-based auth.
+        host_credentials = {
+            "github.com": f"https://x-access-token:{git_token}@github.com",
+            "gitlab.com": f"https://oauth2:{git_token}@gitlab.com",
+            "bitbucket.org": f"https://x-token-auth:{git_token}@bitbucket.org",
+        }
+        for host in host_credentials:
             # Rewrite git@host: → https://host/
             self._run([
                 "docker", "exec", self.container_id,
@@ -179,9 +189,7 @@ class DockerManager:
                 f"url.https://{host}/.insteadOf", f"git@{host}:",
             ])
         # Store credentials so the token is not exposed in remote URLs.
-        cred_lines = "\n".join(
-            f"https://{git_token}@{h}" for h in ("github.com", "gitlab.com", "bitbucket.org")
-        ) + "\n"
+        cred_lines = "\n".join(host_credentials.values()) + "\n"
         self._run([
             "docker", "exec", "-i", self.container_id,
             "bash", "-c", "cat > /root/.git-credentials",
@@ -217,9 +225,7 @@ class DockerManager:
                 print(f"  Warning: {msg}", file=sys.stderr)
                 self.startup_warnings.append(msg)
                 self.ssh_mode = "none"
-                git_token = os.getenv("GIT_TOKEN")
-                if git_token:
-                    self._configure_https_fallback(git_token)
+                self._try_configure_https_fallback()
 
     def exec(self, cmd: list[str], stdin_data: str | None = None) -> tuple[int, str, str]:
         """Execute a command inside the container.

--- a/docker_manager.py
+++ b/docker_manager.py
@@ -18,7 +18,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \\
     python3 python3-pip python3-venv \\
     nodejs npm \\
     golang-go \\
-    git curl wget grep findutils \\
+    git curl wget grep findutils openssh-client \\
     build-essential \\
     && rm -rf /var/lib/apt/lists/*
 
@@ -42,6 +42,7 @@ class DockerManager:
         self.image_tag: str = IMAGE_NAME
         self.subprocess_timeout = subprocess_timeout
         self.startup_warnings: list[str] = []
+        self.ssh_mode: str = "none"  # "none", "agent", or "keys"
         atexit.register(self.cleanup)
 
     def _run(self, cmd: list[str], timeout: int | None = None, **kwargs) -> subprocess.CompletedProcess:
@@ -93,8 +94,26 @@ class DockerManager:
         print(f"  Image '{self.image_tag}' built successfully.", file=sys.stderr)
         return {"status": "built", "image": self.image_tag, "dockerfile": source}
 
+    def _detect_ssh(self) -> dict:
+        """Detect SSH availability on the host. Returns dict with mode and paths."""
+        ssh_auth_sock = os.getenv("SSH_AUTH_SOCK")
+        if ssh_auth_sock and os.path.exists(ssh_auth_sock):
+            return {"mode": "agent", "ssh_auth_sock": ssh_auth_sock}
+
+        ssh_dir = os.path.expanduser("~/.ssh")
+        if os.path.isdir(ssh_dir):
+            for name in ("id_ed25519", "id_rsa", "id_ecdsa"):
+                key_path = os.path.join(ssh_dir, name)
+                if os.path.isfile(key_path):
+                    return {"mode": "keys", "ssh_dir": ssh_dir}
+
+        return {"mode": "none"}
+
     def start_container(self) -> None:
         """Start a persistent container with work_dir mounted."""
+        ssh_info = self._detect_ssh()
+        self.ssh_mode = ssh_info["mode"]
+
         name = f"{CONTAINER_PREFIX}-{uuid.uuid4().hex[:8]}"
         cmd = [
             "docker", "run", "-d",
@@ -102,6 +121,17 @@ class DockerManager:
             "-v", f"{self.work_dir}:{MOUNT_TARGET}",
             "-w", MOUNT_TARGET,
         ]
+
+        # Mount SSH agent socket or SSH keys directory when available.
+        if self.ssh_mode == "agent":
+            host_sock = ssh_info["ssh_auth_sock"]
+            cmd.extend([
+                "-v", f"{host_sock}:/run/ssh-agent.sock:ro",
+                "-e", "SSH_AUTH_SOCK=/run/ssh-agent.sock",
+            ])
+        elif self.ssh_mode == "keys":
+            cmd.extend(["-v", f"{ssh_info['ssh_dir']}:/root/.ssh:ro"])
+
         # Forward optional env vars (e.g. GIT_TOKEN) into the container.
         for var in _ENV_FORWARD:
             val = os.getenv(var)
@@ -112,11 +142,12 @@ class DockerManager:
         if result.returncode != 0:
             raise RuntimeError(f"Container start failed:\n{result.stderr}")
         self.container_id = result.stdout.strip()
-        print(f"  Container started: {name}", file=sys.stderr)
+        print(f"  Container started: {name} (ssh: {self.ssh_mode})", file=sys.stderr)
         self._configure_git()
+        self._configure_ssh()
 
     def _configure_git(self) -> None:
-        """Set git identity inside the container when env vars are present."""
+        """Set git identity and credential helpers inside the container."""
         configs = {
             "user.name": os.getenv("GIT_USER_NAME"),
             "user.email": os.getenv("GIT_USER_EMAIL"),
@@ -131,6 +162,64 @@ class DockerManager:
                     msg = f"Failed to set git {key}: {result.stderr.strip()}"
                     print(f"  Warning: {msg}", file=sys.stderr)
                     self.startup_warnings.append(msg)
+
+        # When SSH is not available, rewrite SSH URLs to HTTPS using GIT_TOKEN.
+        if self.ssh_mode == "none":
+            git_token = os.getenv("GIT_TOKEN")
+            if git_token:
+                self._configure_https_fallback(git_token)
+
+    def _configure_https_fallback(self, git_token: str) -> None:
+        """Set up git to rewrite SSH URLs to HTTPS and authenticate with a token."""
+        for host in ("github.com", "gitlab.com", "bitbucket.org"):
+            # Rewrite git@host: → https://host/
+            self._run([
+                "docker", "exec", self.container_id,
+                "git", "config", "--global",
+                f"url.https://{host}/.insteadOf", f"git@{host}:",
+            ])
+        # Store credentials so the token is not exposed in remote URLs.
+        cred_lines = "\n".join(
+            f"https://{git_token}@{h}" for h in ("github.com", "gitlab.com", "bitbucket.org")
+        ) + "\n"
+        self._run([
+            "docker", "exec", "-i", self.container_id,
+            "bash", "-c", "cat > /root/.git-credentials",
+        ], input=cred_lines)
+        self._run([
+            "docker", "exec", self.container_id,
+            "git", "config", "--global",
+            "credential.helper", "store --file=/root/.git-credentials",
+        ])
+
+    def _configure_ssh(self) -> None:
+        """Configure SSH inside the container based on detected mode."""
+        if self.ssh_mode == "none":
+            return
+
+        # Accept new host keys automatically (fresh container has no known_hosts).
+        self._run([
+            "docker", "exec", self.container_id,
+            "bash", "-c",
+            "mkdir -p /root/.ssh && printf '%s\\n' "
+            "'Host *' '    StrictHostKeyChecking accept-new' "
+            ">> /root/.ssh/config && chmod 600 /root/.ssh/config",
+        ])
+
+        if self.ssh_mode == "agent":
+            # Verify the forwarded agent is usable.
+            result = self._run([
+                "docker", "exec", self.container_id,
+                "ssh-add", "-l",
+            ])
+            if result.returncode != 0:
+                msg = "SSH agent forwarded but no keys accessible — falling back to HTTPS."
+                print(f"  Warning: {msg}", file=sys.stderr)
+                self.startup_warnings.append(msg)
+                self.ssh_mode = "none"
+                git_token = os.getenv("GIT_TOKEN")
+                if git_token:
+                    self._configure_https_fallback(git_token)
 
     def exec(self, cmd: list[str], stdin_data: str | None = None) -> tuple[int, str, str]:
         """Execute a command inside the container.

--- a/tools.py
+++ b/tools.py
@@ -4,6 +4,7 @@ import difflib
 import inspect
 import json
 import os
+import shlex
 
 import requests
 


### PR DESCRIPTION
The Docker sandbox now auto-detects SSH availability on the host and
configures the container accordingly:
- SSH agent forwarding when SSH_AUTH_SOCK is set
- SSH key mounting (read-only) when ~/.ssh keys exist
- Automatic SSH-to-HTTPS URL rewriting via git insteadOf when neither
  is available, using GIT_TOKEN with a credential helper

Also installs openssh-client in the default Dockerfile and fixes a
missing `import shlex` in tools.py.

https://claude.ai/code/session_01FPhUsdGatWTChfgfh6DE7Q