### PR TITLE
fix(webhook): only restart server on pushes to master/main branch

### DIFF
--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -276,7 +276,7 @@ class GitHubWebhookHandler(tornado.web.RequestHandler):
         if event == "push":
             try:
                 payload = json.loads(self.request.body)
-                ref = payload.get("ref", "")
+                ref = payload.get("ref", "") if isinstance(payload, dict) else ""
             except json.JSONDecodeError:
                 logger.warning("GitHub webhook: failed to decode push payload")
                 ref = ""

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -272,8 +272,22 @@ class GitHubWebhookHandler(tornado.web.RequestHandler):
             self.finish()
             return
 
-        # For push events (and others), pull and restart
+        # Only handle push events (and only restart on master/main branch)
         if event == "push":
+            try:
+                payload = json.loads(self.request.body)
+                ref = payload.get("ref", "")
+            except json.JSONDecodeError:
+                logger.warning("GitHub webhook: failed to decode push payload")
+                ref = ""
+
+            # Only restart for pushes to master or main branch
+            if ref not in ("refs/heads/master", "refs/heads/main"):
+                logger.info(f"GitHub webhook: ignoring push to {ref}")
+                self.write({"status": "ok", "event": event, "branch": ref, "action": "ignored"})
+                self.finish()
+                return
+
             try:
                 result = await asyncio.to_thread(
                     subprocess.run,


### PR DESCRIPTION
The webhook handler previously restarted the server on all push events, regardless of which branch was pushed to. This caused unnecessary restarts when pushing to feature branches.

Now the handler:
1. Parses the webhook payload to extract the 'ref' field
2. Only performs git pull and restart for 'refs/heads/master' or 'refs/heads/main'
3. Returns a 200 OK with action 'ignored' for pushes to other branches
4. Logs the branch name being ignored for debugging purposes