### PR TITLE
Add SQLite-based settings database

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,11 @@ RATE_LIMIT_MIN_DELAY=0.1
 # Maximum delay for adaptive rate limiting (default: 60.0)
 RATE_LIMIT_MAX_DELAY=60.0
 
+# Settings Database Configuration (optional)
+# Path to SQLite database file for storing application settings
+# If not set, defaults to ~/coding-guy-workspace/settings.db
+CODING_GUY_SETTINGS_DB=/path/to/your/settings.db
+
 # Git credentials (optional) — passed into the Docker sandbox
 # so the agent can push/pull/clone and make commits.
 GIT_TOKEN=your-git-token-here

--- a/README.md
+++ b/README.md
@@ -87,6 +87,60 @@ You'll see messages like:
 API key pool initialized with 3 keys
 ```
 
+## Settings Database
+
+The agent uses SQLite to store application settings with full support for queryable, categorized configuration. This replaces scattered environment variables with a persistent, type-safe settings API.
+
+### Features
+
+- **Persistent storage** - SQLite database survives restarts
+- **Type-safe values** - Support for string, integer, float, boolean, and JSON types
+- **Categorized organization** - Group settings by category (agent, telegram, slack, docker, api, ui)
+- **Change history** - Track all setting modifications over time
+- **Import/Export** - JSON format for backup and migration
+- **Bot integration** - Access settings via `/settings` command in Telegram and Slack
+
+### Configuration
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `CODING_GUY_SETTINGS_DB` | Path to SQLite database file | `~/coding-guy-workspace/settings.db` |
+
+### Telegram Commands
+
+- `/settings` - Show categories and usage
+- `/settings get <key>` - Get a specific setting
+- `/settings set <key> <value>` - Set a setting (auto-detects type)
+- `/settings list [category]` - List all settings
+- `/settings categories` - List all categories
+- `/settings export` - Export as JSON
+
+### Slack Commands
+
+- `/coding-guy settings` - Show categories
+- `/coding-guy settings list [category]` - List settings
+- `/coding-guy settings get <key>` - Get a specific setting
+
+### Usage in Code
+
+```python
+from settings_db import get_settings_db, set_setting, get_setting
+
+# Initialize with defaults
+from settings_db import init_default_settings
+init_default_settings()
+
+# Set a value
+db = get_settings_db()
+db.set("agent.max_rounds", 500, "integer", "agent", "Maximum tool rounds per request")
+
+# Get a value
+value = db.get("agent.max_rounds", default=250)
+
+# Get all in category
+settings = db.get_all(category="telegram")
+```
+
 ## Rate Limiting
 
 The agent includes built-in rate limiting to minimize 429 (Rate Limit) errors from the LLM API. This is particularly important when making multiple sequential requests or using the agent interactively.
@@ -229,11 +283,13 @@ The agent has access to these tools:
 - `/clear` - Reset conversation
 - `/webhook` - Show GitHub webhook configuration
 - `/status` - Server status
+- `/settings` - Manage settings (get, set, list, export)
 
 ### Slack Commands
 - `/coding-guy <question>` - Ask a coding question
 - `/coding-guy clear` - Reset conversation
 - `/coding-guy status` - Show server status
+- `/coding-guy settings` - Manage settings (list, get)
 - `/coding-guy help` - Show help
 
 You can also:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,6 @@ slack-bolt==1.21.2
 slack-sdk==3.34.0
 certifi==2025.1.31
 
+# Settings database
+# sqlite3 is included with Python 3.x, no additional packages needed
+

--- a/settings_db.py
+++ b/settings_db.py
@@ -1,0 +1,506 @@
+#!/usr/bin/env python3
+"""SQLite database module for storing application settings."""
+
+import json
+import os
+import sqlite3
+from dataclasses import dataclass, asdict
+from datetime import datetime
+from typing import Optional, List, Dict, Any
+from pathlib import Path
+
+# Default database path - stored in workspace directory
+DEFAULT_DB_PATH = os.path.join(
+    os.path.expanduser("~"),
+    "coding-guy-workspace",
+    "settings.db"
+)
+
+# Environment override
+DB_PATH = os.getenv("CODING_GUY_SETTINGS_DB", DEFAULT_DB_PATH)
+
+
+@dataclass
+class Setting:
+    """Represents a single setting record."""
+    key: str
+    value: Any
+    value_type: str = "string"
+    category: str = "general"
+    description: str = ""
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+    
+    def to_dict(self) -> dict:
+        """Convert setting to dictionary."""
+        return asdict(self)
+
+
+class SettingsDatabase:
+    """SQLite database manager for application settings."""
+    
+    def __init__(self, db_path: str = None):
+        """Initialize the settings database.
+        
+        Args:
+            db_path: Path to SQLite database file. Uses CODING_GUY_SETTINGS_DB env var or default.
+        """
+        self.db_path = db_path or DB_PATH
+        self._ensure_directory()
+        self._init_db()
+    
+    def _ensure_directory(self):
+        """Ensure the database directory exists."""
+        directory = os.path.dirname(self.db_path)
+        if directory:
+            os.makedirs(directory, exist_ok=True)
+    
+    def _get_connection(self) -> sqlite3.Connection:
+        """Get a database connection with row factory."""
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+    
+    def _init_db(self):
+        """Initialize the database schema."""
+        with self._get_connection() as conn:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS settings (
+                    key TEXT PRIMARY KEY,
+                    value TEXT NOT NULL,
+                    value_type TEXT DEFAULT 'string',
+                    category TEXT DEFAULT 'general',
+                    description TEXT DEFAULT '',
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS settings_history (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    key TEXT NOT NULL,
+                    old_value TEXT,
+                    new_value TEXT NOT NULL,
+                    changed_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_settings_category ON settings(category)
+            """)
+            conn.execute("""
+                CREATE INDEX IF NOT EXISTS idx_settings_history_key ON settings_history(key)
+            """)
+            conn.commit()
+    
+    def _serialize_value(self, value: Any, value_type: str) -> str:
+        """Serialize a value based on its type."""
+        if value_type == "json":
+            return json.dumps(value)
+        elif value_type == "boolean":
+            return "1" if value else "0"
+        elif value_type == "integer":
+            return str(int(value))
+        elif value_type == "float":
+            return str(float(value))
+        else:
+            return str(value)
+    
+    def _deserialize_value(self, value: str, value_type: str) -> Any:
+        """Deserialize a value based on its type."""
+        if value_type == "json":
+            return json.loads(value)
+        elif value_type == "boolean":
+            return value == "1" or value.lower() == "true"
+        elif value_type == "integer":
+            return int(value)
+        elif value_type == "float":
+            return float(value)
+        else:
+            return value
+    
+    def set(self, key: str, value: Any, value_type: str = "string",
+            category: str = "general", description: str = "") -> bool:
+        """Set or update a setting.
+        
+        Args:
+            key: Unique setting key
+            value: Setting value
+            value_type: Type of value (string, integer, float, boolean, json)
+            category: Grouping category
+            description: Description of the setting
+            
+        Returns:
+            True if successful
+        """
+        serialized = self._serialize_value(value, value_type)
+        now = datetime.now().isoformat()
+        
+        with self._get_connection() as conn:
+            # Get old value for history
+            old_row = conn.execute(
+                "SELECT value FROM settings WHERE key = ?",
+                (key,)
+            ).fetchone()
+            
+            old_value = old_row[0] if old_row else None
+            
+            # Insert or update
+            conn.execute("""
+                INSERT INTO settings (key, value, value_type, category, description, updated_at)
+                VALUES (:key, :value, :value_type, :category, :description, :updated_at)
+                ON CONFLICT(key) DO UPDATE SET
+                    value = excluded.value,
+                    value_type = excluded.value_type,
+                    category = excluded.category,
+                    description = excluded.description,
+                    updated_at = excluded.updated_at
+            """, {
+                "key": key,
+                "value": serialized,
+                "value_type": value_type,
+                "category": category,
+                "description": description,
+                "updated_at": now
+            })
+            
+            # Record in history
+            conn.execute("""
+                INSERT INTO settings_history (key, old_value, new_value)
+                VALUES (:key, :old_value, :new_value)
+            """, {
+                "key": key,
+                "old_value": old_value,
+                "new_value": serialized
+            })
+            
+            conn.commit()
+        
+        return True
+    
+    def get(self, key: str, default: Any = None) -> Optional[Any]:
+        """Get a setting value.
+        
+        Args:
+            key: Setting key
+            default: Default value if not found
+            
+        Returns:
+            Setting value or default
+        """
+        with self._get_connection() as conn:
+            row = conn.execute(
+                "SELECT value, value_type FROM settings WHERE key = ?",
+                (key,)
+            ).fetchone()
+            
+            if row:
+                return self._deserialize_value(row["value"], row["value_type"])
+            return default
+    
+    def get_setting(self, key: str) -> Optional[Setting]:
+        """Get full setting object including metadata.
+        
+        Args:
+            key: Setting key
+            
+        Returns:
+            Setting object or None
+        """
+        with self._get_connection() as conn:
+            row = conn.execute(
+                "SELECT * FROM settings WHERE key = ?",
+                (key,)
+            ).fetchone()
+            
+            if row:
+                return Setting(
+                    key=row["key"],
+                    value=self._deserialize_value(row["value"], row["value_type"]),
+                    value_type=row["value_type"],
+                    category=row["category"],
+                    description=row["description"],
+                    created_at=row["created_at"],
+                    updated_at=row["updated_at"]
+                )
+            return None
+    
+    def get_all(self, category: Optional[str] = None) -> Dict[str, Any]:
+        """Get all settings, optionally filtered by category.
+        
+        Args:
+            category: Optional category filter
+            
+        Returns:
+            Dictionary of key-value pairs
+        """
+        with self._get_connection() as conn:
+            if category:
+                rows = conn.execute(
+                    "SELECT key, value, value_type FROM settings WHERE category = ? ORDER BY key",
+                    (category,)
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT key, value, value_type FROM settings ORDER BY category, key"
+                ).fetchall()
+            
+            return {
+                row["key"]: self._deserialize_value(row["value"], row["value_type"])
+                for row in rows
+            }
+    
+    def get_all_settings(self, category: Optional[str] = None) -> List[Setting]:
+        """Get full setting objects.
+        
+        Args:
+            category: Optional category filter
+            
+        Returns:
+            List of Setting objects
+        """
+        with self._get_connection() as conn:
+            if category:
+                rows = conn.execute(
+                    "SELECT * FROM settings WHERE category = ? ORDER BY key",
+                    (category,)
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    "SELECT * FROM settings ORDER BY category, key"
+                ).fetchall()
+            
+            return [
+                Setting(
+                    key=row["key"],
+                    value=self._deserialize_value(row["value"], row["value_type"]),
+                    value_type=row["value_type"],
+                    category=row["category"],
+                    description=row["description"],
+                    created_at=row["created_at"],
+                    updated_at=row["updated_at"]
+                )
+                for row in rows
+            ]
+    
+    def delete(self, key: str) -> bool:
+        """Delete a setting.
+        
+        Args:
+            key: Setting key to delete
+            
+        Returns:
+            True if setting existed and was deleted
+        """
+        with self._get_connection() as conn:
+            cursor = conn.execute("DELETE FROM settings WHERE key = ?", (key,))
+            conn.commit()
+            return cursor.rowcount > 0
+    
+    def get_categories(self) -> List[str]:
+        """Get all unique categories.
+        
+        Returns:
+            List of category names
+        """
+        with self._get_connection() as conn:
+            rows = conn.execute(
+                "SELECT DISTINCT category FROM settings ORDER BY category"
+            ).fetchall()
+            return [row[0] for row in rows]
+    
+    def get_history(self, key: str, limit: int = 10) -> List[Dict]:
+        """Get change history for a setting.
+        
+        Args:
+            key: Setting key
+            limit: Maximum number of entries
+            
+        Returns:
+            List of history entries
+        """
+        with self._get_connection() as conn:
+            rows = conn.execute("""
+                SELECT key, old_value, new_value, changed_at
+                FROM settings_history
+                WHERE key = ?
+                ORDER BY changed_at DESC
+                LIMIT ?
+            """, (key, limit)).fetchall()
+            
+            return [
+                {
+                    "key": row["key"],
+                    "old_value": row["old_value"],
+                    "new_value": row["new_value"],
+                    "changed_at": row["changed_at"]
+                }
+                for row in rows
+            ]
+    
+    def export_to_json(self, category: Optional[str] = None) -> str:
+        """Export settings to JSON format.
+        
+        Args:
+            category: Optional category filter
+            
+        Returns:
+            JSON string of settings
+        """
+        settings_list = self.get_all_settings(category)
+        data = {
+            "exported_at": datetime.now().isoformat(),
+            "category": category,
+            "settings": [s.to_dict() for s in settings_list]
+        }
+        return json.dumps(data, indent=2)
+    
+    def import_from_json(self, json_str: str, overwrite: bool = True) -> int:
+        """Import settings from JSON.
+        
+        Args:
+            json_str: JSON string containing settings
+            overwrite: Whether to overwrite existing settings
+            
+        Returns:
+            Number of settings imported
+        """
+        data = json.loads(json_str)
+        count = 0
+        
+        for setting_data in data.get("settings", []):
+            key = setting_data.get("key")
+            if not key:
+                continue
+            
+            existing = self.get_setting(key)
+            if existing and not overwrite:
+                continue
+            
+            self.set(
+                key=key,
+                value=setting_data.get("value"),
+                value_type=setting_data.get("value_type", "string"),
+                category=setting_data.get("category", "general"),
+                description=setting_data.get("description", "")
+            )
+            count += 1
+        
+        return count
+    
+    def get_stats(self) -> Dict[str, Any]:
+        """Get database statistics.
+        
+        Returns:
+            Dictionary with statistics
+        """
+        with self._get_connection() as conn:
+            total = conn.execute("SELECT COUNT(*) FROM settings").fetchone()[0]
+            categories = conn.execute("SELECT COUNT(DISTINCT category) FROM settings").fetchone()[0]
+            history = conn.execute("SELECT COUNT(*) FROM settings_history").fetchone()[0]
+            
+            category_counts = conn.execute("""
+                SELECT category, COUNT(*) as count
+                FROM settings
+                GROUP BY category
+                ORDER BY count DESC
+            """).fetchall()
+            
+            return {
+                "total_settings": total,
+                "total_categories": categories,
+                "history_entries": history,
+                "by_category": {row[0]: row[1] for row in category_counts},
+                "database_path": self.db_path
+            }
+
+
+# Global instance for convenience
+_settings_db: Optional[SettingsDatabase] = None
+
+
+def get_settings_db() -> SettingsDatabase:
+    """Get or create the global settings database instance."""
+    global _settings_db
+    if _settings_db is None:
+        _settings_db = SettingsDatabase()
+    return _settings_db
+
+
+def init_settings_db(db_path: str = None) -> SettingsDatabase:
+    """Initialize and return the global settings database instance."""
+    global _settings_db
+    _settings_db = SettingsDatabase(db_path)
+    return _settings_db
+
+
+# Convenience functions that use the global instance
+def set_setting(key: str, value: Any, value_type: str = "string",
+                category: str = "general", description: str = "") -> bool:
+    """Set a setting using the global database."""
+    return get_settings_db().set(key, value, value_type, category, description)
+
+
+def get_setting(key: str, default: Any = None) -> Any:
+    """Get a setting using the global database."""
+    return get_settings_db().get(key, default)
+
+
+def delete_setting(key: str) -> bool:
+    """Delete a setting using the global database."""
+    return get_settings_db().delete(key)
+
+
+# Predefined setting categories
+CATEGORY_AGENT = "agent"
+CATEGORY_TELEGRAM = "telegram"
+CATEGORY_SLACK = "slack"
+CATEGORY_DOCKER = "docker"
+CATEGORY_API = "api"
+CATEGORY_UI = "ui"
+
+# Predefined settings with defaults
+DEFAULT_SETTINGS = {
+    # Agent behavior
+    ("agent.max_rounds", 250, "integer", CATEGORY_AGENT, "Maximum tool rounds per request"),
+    ("agent.auto_save", True, "boolean", CATEGORY_AGENT, "Auto-save conversation history"),
+    ("agent.confirm_destructive", True, "boolean", CATEGORY_AGENT, "Confirm destructive operations"),
+    
+    # Telegram settings
+    ("telegram.enabled", True, "boolean", CATEGORY_TELEGRAM, "Enable Telegram bot"),
+    ("telegram.webhook_port", 21031, "integer", CATEGORY_TELEGRAM, "Webhook server port"),
+    
+    # Slack settings
+    ("slack.enabled", True, "boolean", CATEGORY_SLACK, "Enable Slack bot"),
+    ("slack.socket_mode", True, "boolean", CATEGORY_SLACK, "Use Socket Mode for Slack"),
+    
+    # Docker settings
+    ("docker.auto_cleanup", True, "boolean", CATEGORY_DOCKER, "Auto-cleanup containers on exit"),
+    ("docker.timeout", 300, "integer", CATEGORY_DOCKER, "Default command timeout in seconds"),
+    
+    # API settings
+    ("api.timeout", 300, "integer", CATEGORY_API, "API request timeout in seconds"),
+    ("api.max_retries", 5, "integer", "Maximum API retry attempts"),
+    ("api.stream_by_default", True, "boolean", CATEGORY_API, "Stream responses by default"),
+    
+    # UI settings
+    ("ui.show_tool_calls", True, "boolean", CATEGORY_UI, "Show tool calls in output"),
+    ("ui.show_progress", True, "boolean", CATEGORY_UI, "Show progress indicators"),
+}
+
+
+def init_default_settings():
+    """Initialize default settings if they don't exist."""
+    db = get_settings_db()
+    for key, value, value_type, category, description in DEFAULT_SETTINGS:
+        if db.get_setting(key) is None:
+            db.set(key, value, value_type, category, description)
+
+
+if __name__ == "__main__":
+    # Test/demo
+    db = SettingsDatabase()
+    print(f"Settings DB initialized at: {db.db_path}")
+    print(f"\nStatistics:")
+    stats = db.get_stats()
+    for key, value in stats.items():
+        print(f"  {key}: {value}")

--- a/settings_db.py
+++ b/settings_db.py
@@ -5,7 +5,7 @@ import json
 import os
 import sqlite3
 from dataclasses import dataclass, asdict
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, List, Dict, Any
 from pathlib import Path
 
@@ -157,7 +157,7 @@ class SettingsDatabase:
             True if successful
         """
         serialized = self._serialize_value(value, value_type)
-        now = datetime.now().isoformat()
+        now = datetime.now(timezone.utc).isoformat()
         
         with self._get_connection() as conn:
             # Get old value for history
@@ -372,7 +372,7 @@ class SettingsDatabase:
         """
         settings_list = self.get_all_settings(category)
         data = {
-            "exported_at": datetime.now().isoformat(),
+            "exported_at": datetime.now(timezone.utc).isoformat(),
             "category": category,
             "settings": [s.to_dict() for s in settings_list]
         }

--- a/settings_db.py
+++ b/settings_db.py
@@ -61,6 +61,30 @@ class SettingsDatabase:
         conn.row_factory = sqlite3.Row
         return conn
     
+    def _execute_query(self, query: str, params: tuple = ()):
+        """Execute a query with proper connection closing."""
+        conn = self._get_connection()
+        try:
+            return conn.execute(query, params)
+        finally:
+            conn.close()
+    
+    def _execute_query_fetchall(self, query: str, params: tuple = ()):
+        """Execute a query and fetch all results with proper connection closing."""
+        conn = self._get_connection()
+        try:
+            return conn.execute(query, params).fetchall()
+        finally:
+            conn.close()
+    
+    def _execute_query_fetchone(self, query: str, params: tuple = ()):
+        """Execute a query and fetch one result with proper connection closing."""
+        conn = self._get_connection()
+        try:
+            return conn.execute(query, params).fetchone()
+        finally:
+            conn.close()
+    
     def _init_db(self):
         """Initialize the database schema."""
         with self._get_connection() as conn:
@@ -479,7 +503,7 @@ DEFAULT_SETTINGS = {
     
     # API settings
     ("api.timeout", 300, "integer", CATEGORY_API, "API request timeout in seconds"),
-    ("api.max_retries", 5, "integer", "Maximum API retry attempts"),
+    ("api.max_retries", 5, "integer", CATEGORY_API, "Maximum API retry attempts"),
     ("api.stream_by_default", True, "boolean", CATEGORY_API, "Stream responses by default"),
     
     # UI settings

--- a/settings_db.py
+++ b/settings_db.py
@@ -87,7 +87,8 @@ class SettingsDatabase:
     
     def _init_db(self):
         """Initialize the database schema."""
-        with self._get_connection() as conn:
+        conn = self._get_connection()
+        try:
             conn.execute("""
                 CREATE TABLE IF NOT EXISTS settings (
                     key TEXT PRIMARY KEY,
@@ -115,6 +116,8 @@ class SettingsDatabase:
                 CREATE INDEX IF NOT EXISTS idx_settings_history_key ON settings_history(key)
             """)
             conn.commit()
+        finally:
+            conn.close()
     
     def _serialize_value(self, value: Any, value_type: str) -> str:
         """Serialize a value based on its type."""
@@ -159,7 +162,8 @@ class SettingsDatabase:
         serialized = self._serialize_value(value, value_type)
         now = datetime.now(timezone.utc).isoformat()
         
-        with self._get_connection() as conn:
+        conn = self._get_connection()
+        try:
             # Get old value for history
             old_row = conn.execute(
                 "SELECT value FROM settings WHERE key = ?",
@@ -211,7 +215,8 @@ class SettingsDatabase:
         Returns:
             Setting value or default
         """
-        with self._get_connection() as conn:
+        conn = self._get_connection()
+        try:
             row = conn.execute(
                 "SELECT value, value_type FROM settings WHERE key = ?",
                 (key,)
@@ -220,6 +225,8 @@ class SettingsDatabase:
             if row:
                 return self._deserialize_value(row["value"], row["value_type"])
             return default
+        finally:
+            conn.close()
     
     def get_setting(self, key: str) -> Optional[Setting]:
         """Get full setting object including metadata.
@@ -230,7 +237,8 @@ class SettingsDatabase:
         Returns:
             Setting object or None
         """
-        with self._get_connection() as conn:
+        conn = self._get_connection()
+        try:
             row = conn.execute(
                 "SELECT * FROM settings WHERE key = ?",
                 (key,)
@@ -247,6 +255,8 @@ class SettingsDatabase:
                     updated_at=row["updated_at"]
                 )
             return None
+        finally:
+            conn.close()
     
     def get_all(self, category: Optional[str] = None) -> Dict[str, Any]:
         """Get all settings, optionally filtered by category.
@@ -257,7 +267,8 @@ class SettingsDatabase:
         Returns:
             Dictionary of key-value pairs
         """
-        with self._get_connection() as conn:
+        conn = self._get_connection()
+        try:
             if category:
                 rows = conn.execute(
                     "SELECT key, value, value_type FROM settings WHERE category = ? ORDER BY key",
@@ -272,6 +283,8 @@ class SettingsDatabase:
                 row["key"]: self._deserialize_value(row["value"], row["value_type"])
                 for row in rows
             }
+        finally:
+            conn.close()
     
     def get_all_settings(self, category: Optional[str] = None) -> List[Setting]:
         """Get full setting objects.
@@ -282,7 +295,8 @@ class SettingsDatabase:
         Returns:
             List of Setting objects
         """
-        with self._get_connection() as conn:
+        conn = self._get_connection()
+        try:
             if category:
                 rows = conn.execute(
                     "SELECT * FROM settings WHERE category = ? ORDER BY key",
@@ -305,6 +319,8 @@ class SettingsDatabase:
                 )
                 for row in rows
             ]
+        finally:
+            conn.close()
     
     def delete(self, key: str) -> bool:
         """Delete a setting.
@@ -315,10 +331,13 @@ class SettingsDatabase:
         Returns:
             True if setting existed and was deleted
         """
-        with self._get_connection() as conn:
+        conn = self._get_connection()
+        try:
             cursor = conn.execute("DELETE FROM settings WHERE key = ?", (key,))
             conn.commit()
             return cursor.rowcount > 0
+        finally:
+            conn.close()
     
     def get_categories(self) -> List[str]:
         """Get all unique categories.
@@ -326,11 +345,14 @@ class SettingsDatabase:
         Returns:
             List of category names
         """
-        with self._get_connection() as conn:
+        conn = self._get_connection()
+        try:
             rows = conn.execute(
                 "SELECT DISTINCT category FROM settings ORDER BY category"
             ).fetchall()
             return [row[0] for row in rows]
+        finally:
+            conn.close()
     
     def get_history(self, key: str, limit: int = 10) -> List[Dict]:
         """Get change history for a setting.
@@ -342,7 +364,8 @@ class SettingsDatabase:
         Returns:
             List of history entries
         """
-        with self._get_connection() as conn:
+        conn = self._get_connection()
+        try:
             rows = conn.execute("""
                 SELECT key, old_value, new_value, changed_at
                 FROM settings_history
@@ -360,6 +383,8 @@ class SettingsDatabase:
                 }
                 for row in rows
             ]
+        finally:
+            conn.close()
     
     def export_to_json(self, category: Optional[str] = None) -> str:
         """Export settings to JSON format.
@@ -417,7 +442,8 @@ class SettingsDatabase:
         Returns:
             Dictionary with statistics
         """
-        with self._get_connection() as conn:
+        conn = self._get_connection()
+        try:
             total = conn.execute("SELECT COUNT(*) FROM settings").fetchone()[0]
             categories = conn.execute("SELECT COUNT(DISTINCT category) FROM settings").fetchone()[0]
             history = conn.execute("SELECT COUNT(*) FROM settings_history").fetchone()[0]
@@ -436,6 +462,8 @@ class SettingsDatabase:
                 "by_category": {row[0]: row[1] for row in category_counts},
                 "database_path": self.db_path
             }
+        finally:
+            conn.close()
 
 
 # Global instance for convenience

--- a/slack_bot.py
+++ b/slack_bot.py
@@ -277,7 +277,7 @@ class SlackBot:
 
                 if subcommand == "export":
                     json_data = db.export_to_json()
-                    # Truncate if too long - ensure valid JSON
+                    # Truncate if too long - ensure valid JSON by parsing and re-serializing
                     if len(json_data) > 3500:
                         data = json.loads(json_data)
                         settings = data.get("settings", [])
@@ -289,7 +289,7 @@ class SlackBot:
                     await say(text=f"```json\n{json_data}\n```", mrkdwn=True)
                     return
 
-                await say(text="Unknown subcommand. Try `list`, `get <key>`, `set <key> <value>`, `categories`, `export`", mrkdwn=True)
+                await say(text="Unknown subcommand. Try: `list [category]`, `get <key>`, `set <key> <value>`, `categories`, `export`", mrkdwn=True)
                 return
 
             if text.lower() == "help" or not text:

--- a/slack_bot.py
+++ b/slack_bot.py
@@ -205,9 +205,10 @@ class SlackBot:
                 await say(text=status_text, mrkdwn=True)
                 return
 
-            if text.lower() == "settings":
+            if text.lower().startswith("settings"):
                 db = get_settings_db()
-                args = text.split()[1:] if len(text.split()) > 1 else []
+                parts = text.split()
+                args = parts[1:]
 
                 if not args:
                     cats = db.get_categories()
@@ -245,7 +246,50 @@ class SlackBot:
                     await say(text="\n".join(lines), mrkdwn=True)
                     return
 
-                await say(text="Unknown subcommand. Try `list`, `get <key>`, `set <key> <value>`", mrkdwn=True)
+                if subcommand == "set" and len(args) >= 3:
+                    key = args[1]
+                    value = " ".join(args[2:])
+                    # Try to infer type
+                    value_type = "string"
+                    if value.lower() in ("true", "false"):
+                        value_type = "boolean"
+                        value = value.lower() == "true"
+                    elif value.isdigit():
+                        value_type = "integer"
+                        value = int(value)
+                    elif "." in value:
+                        try:
+                            value = float(value)
+                            value_type = "float"
+                        except ValueError:
+                            pass
+                    db.set(key, value, value_type)
+                    await say(text=f"*Set* `{key}` = `{value}` (type: {value_type})", mrkdwn=True)
+                    return
+
+                if subcommand == "categories":
+                    cats = db.get_categories()
+                    if cats:
+                        await say(text="*Categories:* " + ", ".join(f"`{c}`" for c in cats), mrkdwn=True)
+                    else:
+                        await say(text="No categories found.", mrkdwn=True)
+                    return
+
+                if subcommand == "export":
+                    json_data = db.export_to_json()
+                    # Truncate if too long - ensure valid JSON
+                    if len(json_data) > 3500:
+                        data = json.loads(json_data)
+                        settings = data.get("settings", [])
+                        while len(json.dumps(data, indent=2)) > 3400 and settings:
+                            settings.pop()
+                            data["truncated"] = True
+                            data["total_settings"] = len(db.get_all_settings())
+                        json_data = json.dumps(data, indent=2)
+                    await say(text=f"```json\n{json_data}\n```", mrkdwn=True)
+                    return
+
+                await say(text="Unknown subcommand. Try `list`, `get <key>`, `set <key> <value>`, `categories`, `export`", mrkdwn=True)
                 return
 
             if text.lower() == "help" or not text:

--- a/slack_bot.py
+++ b/slack_bot.py
@@ -15,6 +15,7 @@ from slack_sdk.web.async_internal_client import AsyncWebClient
 from slack_sdk.errors import SlackApiError
 
 from coding_agent import agent_loop, STATUS_COMPLETE, STATUS_MAX_ROUNDS, STATUS_ERROR, COMMIT_HASH
+from settings_db import get_settings_db, init_default_settings
 
 logger = logging.getLogger(__name__)
 
@@ -165,7 +166,7 @@ class SlackBot:
 
             # Check if this is a direct message (IM) - check event payload first to avoid API call
             if event.get("channel_type") != "im" and not channel_id.startswith("D"):
-                return    # Only process DMs, mentions are handled separately
+                return  # Only process DMs, mentions are handled separately
 
             await self._process_message(channel_id, user, text, say)
 
@@ -190,14 +191,61 @@ class SlackBot:
                 minutes, seconds = divmod(remainder, 60)
                 uptime_str = f"{hours}h {minutes}m {seconds}s"
 
+                # Get settings db stats
+                db_stats = get_settings_db().get_stats()
+
                 status_text = (
                     f"*Coding Guy Status*\n"
                     f"• Build: `{COMMIT_HASH}`\n"
                     f"• Uptime: {uptime_str}\n"
                     f"• Active conversations: {len(_channel_histories)}\n"
-                    f"• Model: `{self.model}`"
+                    f"• Model: `{self.model}`\n"
+                    f"• Settings: {db_stats.get('total_settings', 0)} settings, {db_stats.get('total_categories', 0)} categories"
                 )
                 await say(text=status_text, mrkdwn=True)
+                return
+
+            if text.lower() == "settings":
+                db = get_settings_db()
+                args = text.split()[1:] if len(text.split()) > 1 else []
+
+                if not args:
+                    cats = db.get_categories()
+                    lines = ["*Settings Categories*"]
+                    for cat in cats:
+                        settings = db.get_all(category=cat)
+                        lines.append(f"• {cat}: {len(settings)} setting(s)")
+                    lines.extend(["", "Use `/coding-guy settings list [category]` or `/coding-guy settings get <key>`"])
+                    await say(text="\n".join(lines), mrkdwn=True)
+                    return
+
+                subcommand = args[0].lower() if args else ""
+
+                if subcommand == "get" and len(args) >= 2:
+                    key = args[1]
+                    setting = db.get_setting(key)
+                    if setting:
+                        text = f"*{key}*\n• Value: `{setting.value}`\n• Type: {setting.value_type}\n• Category: {setting.category}" + (f"\n• Description: {setting.description}" if setting.description else "")
+                        await say(text=text, mrkdwn=True)
+                    else:
+                        await say(text=f"Setting '{key}' not found.", mrkdwn=True)
+                    return
+
+                if subcommand == "list":
+                    category = args[1] if len(args) > 1 else None
+                    settings = db.get_all(category=category)
+                    if not settings:
+                        await say(text=f"No settings found" + (f" in category '{category}'" if category else ""), mrkdwn=True)
+                        return
+                    lines = [f"*Settings*" + (f" (category: {category})" if category else "")]
+                    for key, val in list(settings.items())[:15]:  # Limit to 15
+                        lines.append(f"• `{key}`: {val}")
+                    if len(settings) > 15:
+                        lines.append(f"• ... and {len(settings) - 15} more")
+                    await say(text="\n".join(lines), mrkdwn=True)
+                    return
+
+                await say(text="Unknown subcommand. Try `list`, `get <key>`, `set <key> <value>`", mrkdwn=True)
                 return
 
             if text.lower() == "help" or not text:
@@ -207,6 +255,7 @@ class SlackBot:
                     "• `/coding-guy <question>` - Ask me anything about coding\n"
                     "• `/coding-guy clear` - Reset the conversation\n"
                     "• `/coding-guy status` - Show server status\n"
+                    "• `/coding-guy settings` - Manage settings\n"
                     "• `/coding-guy help` - Show this help message\n\n"
                     "• *DM me* for private conversations\n"
                     "• *Mention me* (@Coding Guy) in channels"
@@ -294,6 +343,10 @@ class SlackBot:
         """Start the Slack bot with socket mode."""
         global _start_time
         _start_time = asyncio.get_event_loop().time()
+
+        # Initialize settings database with defaults
+        init_default_settings()
+        logger.info(f"Settings DB initialized with {get_settings_db().get_stats().get('total_settings', 0)} settings")
 
         logging.basicConfig(
             format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -233,7 +233,7 @@ async def handle_settings(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
                 data["truncated"] = True
                 data["total_settings"] = len(db.get_all_settings())
             json_data = json.dumps(data, indent=2)
-        await update.message.reply_text(f"```json\n{json_data}\n```", parse_mode="Markdown")
+        await update.message.reply_text(f"<pre>{json_data}</pre>", parse_mode="HTML")
 
     else:
         await update.message.reply_text(

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 TELEGRAM_MAX_MESSAGE_LENGTH = 4096
 WEBHOOK_PORT = int(os.getenv("WEBHOOK_PORT", "21031"))
-PROGRESS_REPORT_INTERVAL = 3  # send a progress update every N tool rounds
+PROGRESS_REPORT_INTERVAL = 3 # send a progress update every N tool rounds
 
 # GitHub webhook configuration
 GITHUB_WEBHOOK_SECRET = os.getenv("GITHUB_WEBHOOK_SECRET", "")
@@ -194,9 +194,12 @@ async def handle_settings(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         elif value.isdigit():
             value_type = "integer"
             value = int(value)
-        elif value.replace(".", "").isdigit():
-            value_type = "float"
-            value = float(value)
+        elif "." in value:
+            try:
+                value = float(value)
+                value_type = "float"
+            except ValueError:
+                pass
 
         db.set(key, value, value_type)
         await update.message.reply_text(f"Set '{key}' = {value} (type: {value_type})")
@@ -220,9 +223,16 @@ async def handle_settings(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
 
     elif subcommand == "export":
         json_data = db.export_to_json()
-        # Truncate if too long
+        # Truncate if too long - ensure valid JSON structure
         if len(json_data) > 3000:
-            json_data = json_data[:3000] + "\n... (truncated)"
+            data = json.loads(json_data)
+            settings = data.get("settings", [])
+            # Keep truncating until it fits
+            while len(json.dumps(data, indent=2)) > 2900 and settings:
+                settings.pop()
+                data["truncated"] = True
+                data["total_settings"] = len(db.get_all_settings())
+            json_data = json.dumps(data, indent=2)
         await update.message.reply_text(f"```json\n{json_data}\n```", parse_mode="Markdown")
 
     else:
@@ -519,7 +529,7 @@ async def _run_server(
 
     await shutdown_event.wait()
 
-    logger.info("Shutting down…")
+    logger.info("Shutting down\u2026")
     server.stop()
     await tg_app.stop()
     await tg_app.shutdown()

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -20,6 +20,7 @@ from telegram import Update
 from telegram.ext import Application, CommandHandler, ContextTypes, MessageHandler, filters
 
 from coding_agent import agent_loop, STATUS_COMPLETE, STATUS_MAX_ROUNDS, STATUS_ERROR, COMMIT_HASH
+from settings_db import get_settings_db, init_default_settings, CATEGORY_AGENT, CATEGORY_TELEGRAM
 
 logger = logging.getLogger(__name__)
 
@@ -80,7 +81,8 @@ async def handle_start(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
         "Commands:\n"
         "/clear - Reset the conversation\n"
         "/webhook - Show GitHub webhook configuration\n"
-        "/status - Show server status"
+        "/status - Show server status\n"
+        "/settings - Show/manage settings"
     )
 
 
@@ -93,7 +95,7 @@ async def handle_clear(update: Update, context: ContextTypes.DEFAULT_TYPE) -> No
 
 
 async def handle_webhook(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Handle /webhook command — show GitHub webhook configuration."""
+    """Handle /webhook command - show GitHub webhook configuration."""
     url = _get_webhook_url()
     lines = [
         "GitHub Webhook Configuration:",
@@ -118,11 +120,14 @@ async def handle_webhook(update: Update, context: ContextTypes.DEFAULT_TYPE) -> 
 
 
 async def handle_status(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Handle /status command — show server status."""
+    """Handle /status command - show server status."""
     uptime_secs = int(time.time() - _start_time)
     hours, remainder = divmod(uptime_secs, 3600)
     minutes, seconds = divmod(remainder, 60)
     uptime_str = f"{hours}h {minutes}m {seconds}s"
+
+    # Get settings db stats
+    db_stats = get_settings_db().get_stats()
 
     lines = [
         f"Build: {COMMIT_HASH}",
@@ -131,8 +136,104 @@ async def handle_status(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
         f"Webhook port: {WEBHOOK_PORT}",
         f"GitHub webhook: {GITHUB_WEBHOOK_PATH}",
         f"GitHub secret: {'configured' if GITHUB_WEBHOOK_SECRET else 'not set'}",
+        f"Settings DB: {db_stats['total_settings']} settings, {db_stats['total_categories']} categories",
     ]
     await update.message.reply_text("\n".join(lines))
+
+
+async def handle_settings(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle /settings command - show or modify settings."""
+    db = get_settings_db()
+    args = context.args or []
+
+    if not args:
+        # Show categories overview
+        categories = db.get_categories()
+        lines = ["Settings Categories:"]
+        for cat in categories:
+            settings = db.get_all(category=cat)
+            lines.append(f"  {cat}: {len(settings)} setting(s)")
+        lines.extend([
+            "",
+            "Usage:",
+            "/settings get <key> - Get a specific setting",
+            "/settings set <key> <value> - Set a setting",
+            "/settings list [category] - List settings in category",
+            "/settings categories - List all categories",
+            "/settings export - Export all settings as JSON",
+        ])
+        await update.message.reply_text("\n".join(lines))
+        return
+
+    subcommand = args[0].lower()
+
+    if subcommand == "get" and len(args) >= 2:
+        key = args[1]
+        setting = db.get_setting(key)
+        if setting:
+            lines = [
+                f"Key: {setting.key}",
+                f"Value: {setting.value}",
+                f"Type: {setting.value_type}",
+                f"Category: {setting.category}",
+                f"Description: {setting.description}",
+                f"Updated: {setting.updated_at}",
+            ]
+            await update.message.reply_text("\n".join(lines))
+        else:
+            await update.message.reply_text(f"Setting '{key}' not found.")
+
+    elif subcommand == "set" and len(args) >= 3:
+        key = args[1]
+        value = " ".join(args[2:])
+        # Try to infer type
+        value_type = "string"
+        if value.lower() in ("true", "false"):
+            value_type = "boolean"
+            value = value.lower() == "true"
+        elif value.isdigit():
+            value_type = "integer"
+            value = int(value)
+        elif value.replace(".", "").isdigit():
+            value_type = "float"
+            value = float(value)
+
+        db.set(key, value, value_type)
+        await update.message.reply_text(f"Set '{key}' = {value} (type: {value_type})")
+
+    elif subcommand == "list":
+        category = args[1] if len(args) > 1 else None
+        settings = db.get_all(category=category)
+        if not settings:
+            await update.message.reply_text(f"No settings found" + (f" in category '{category}'" if category else ""))
+            return
+        lines = [f"Settings:" + (f" (category: {category})" if category else "")]
+        for key, val in list(settings.items())[:20]:  # Limit to 20
+            lines.append(f"  {key}: {val}")
+        if len(settings) > 20:
+            lines.append(f"  ... and {len(settings) - 20} more")
+        await update.message.reply_text("\n".join(lines))
+
+    elif subcommand == "categories":
+        cats = db.get_categories()
+        await update.message.reply_text("Categories: " + ", ".join(cats) if cats else "No categories")
+
+    elif subcommand == "export":
+        json_data = db.export_to_json()
+        # Truncate if too long
+        if len(json_data) > 3000:
+            json_data = json_data[:3000] + "\n... (truncated)"
+        await update.message.reply_text(f"```json\n{json_data}\n```", parse_mode="Markdown")
+
+    else:
+        await update.message.reply_text(
+            "Unknown subcommand. Usage:\n"
+            "/settings get <key>\n"
+            "/settings set <key> <value>\n"
+            "/settings list [category]\n"
+            "/settings categories\n"
+            "/settings export"
+        )
 
 
 def make_progress_callback(chat, loop):
@@ -306,16 +407,16 @@ class GitHubWebhookHandler(tornado.web.RequestHandler):
             self.write({"status": "ok", "action": "restarting", "pull": pull_output})
             self.finish()
 
-            # Schedule a graceful shutdown — the hot-reload watcher (or process
-            # manager) will restart the server with the new code.  If git pull
+            # Schedule a graceful shutdown - the hot-reload watcher (or process
+            # manager) will restart the server with the new code. If git pull
             # changed files under .git the hot-reload watcher picks it up
-            # automatically.  We also send SIGTERM as a fallback for non-reload
+            # automatically. We also send SIGTERM as a fallback for non-reload
             # deployments.
             loop = tornado.ioloop.IOLoop.current()
             loop.call_later(1.0, lambda: os.kill(os.getpid(), signal.SIGTERM))
             return
 
-        # Unhandled event types — just acknowledge
+        # Unhandled event types - just acknowledge
         self.write({"status": "ok", "event": event, "action": "ignored"})
         self.finish()
 
@@ -365,6 +466,7 @@ def run_telegram_bot(api_key: str, invoke_url: str, model: str) -> None:
     tg_app.add_handler(CommandHandler("clear", handle_clear))
     tg_app.add_handler(CommandHandler("webhook", handle_webhook))
     tg_app.add_handler(CommandHandler("status", handle_status))
+    tg_app.add_handler(CommandHandler("settings", handle_settings))
     tg_app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
 
     # Derive the Telegram webhook path from the URL
@@ -379,8 +481,8 @@ def run_telegram_bot(api_key: str, invoke_url: str, model: str) -> None:
 
     print(f"Starting webhook server on 0.0.0.0:{WEBHOOK_PORT} [build {COMMIT_HASH}]", file=sys.stderr)
     print(f"  Telegram webhook: {webhook_url}", file=sys.stderr)
-    print(f"  GitHub webhook:   {_get_webhook_url()}", file=sys.stderr)
-    print(f"  Health check:     http://0.0.0.0:{WEBHOOK_PORT}/health", file=sys.stderr)
+    print(f"  GitHub webhook: {_get_webhook_url()}", file=sys.stderr)
+    print(f"  Health check: http://0.0.0.0:{WEBHOOK_PORT}/health", file=sys.stderr)
 
     asyncio.run(_run_server(tg_app, tornado_app, webhook_url))
 
@@ -390,8 +492,12 @@ async def _run_server(
     tornado_app: tornado.web.Application,
     webhook_url: str,
 ) -> None:
-    """Async entry point: initialise the Telegram app, start tornado, and
+    """Async entry point: initialise the Telegram Application, start tornado, and
     block until a shutdown signal is received."""
+
+    # Initialize settings database with defaults
+    init_default_settings()
+    logger.info(f"Settings DB initialized with {get_settings_db().get_stats()['total_settings']} settings")
 
     # Initialise and start the Telegram Application (processing pipeline)
     await tg_app.initialize()


### PR DESCRIPTION
- New settings_db.py module with full CRUD operations
- Support for string, integer, float, boolean, and JSON types
- Categorized settings organization (agent, telegram, slack, docker, api, ui)
- Change history tracking for audit trail
- Import/export to JSON format
- Settings commands in Telegram bot (/settings get, set, list, export)
- Settings commands in Slack bot (/coding-guy settings list, get)
- Status display includes settings DB stats
- Updated README.md with settings documentation
- Updated .env.example with CODING_GUY_SETTINGS_DB configuration