### PR TITLE
Add pre-commit hook for Python syntax checking

### DIFF
--- a/.githooks/README.md
+++ b/.githooks/README.md
@@ -1,0 +1,47 @@
+# Git Hooks
+
+This directory contains git hooks for the Coding-Guy project.
+
+## Pre-commit Hook
+
+The `pre-commit` hook automatically checks Python syntax on all staged Python files before allowing a commit to proceed.
+
+### What it does
+
+- Runs `python -m py_compile` on all staged `.py` files
+- Prevents the commit if any file has syntax errors
+- Shows the actual error message for debugging
+
+### Installation
+
+To use these hooks, configure git to use the version-controlled hooks directory:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+Or set it globally for this repository:
+
+```bash
+git config --local core.hooksPath .githooks
+```
+
+### Testing the hook
+
+To verify the hook is working:
+
+1. Make a small change to any Python file
+2. Stage the file: `git add <filename>`
+3. Attempt to commit: `git commit -m "test"`
+
+The hook will output syntax check results for all staged Python files.
+
+### Bypassing the hook (not recommended)
+
+In rare cases, you can bypass the pre-commit hook with:
+
+```bash
+git commit --no-verify -m "Your message"
+```
+
+Only use `--no-verify` when absolutely necessary.

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,17 +7,25 @@
 echo "Running Python syntax check on staged files..."
 
 # Get list of staged Python files
-STAGED_PY_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.py$')
+# Get list of staged Python files
+STAGED_PY_FILES=$(git diff --cached --name-only --diff-filter=ACM -- '*.py')
 
 if [ -z "$STAGED_PY_FILES" ]; then
     echo "No Python files staged for commit."
     exit 0
 fi
 
+# Ensure python3 is available
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "ERROR: python3 is not installed or not in PATH."
+    exit 1
+fi
+
 # Track if any syntax errors are found
 SYNTAX_ERRORS=0
 
 # Check each staged Python file
+IFS=$'\n'
 for FILE in $STAGED_PY_FILES; do
     # Only check if file exists (not deleted)
     if [ -f "$FILE" ]; then

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -32,12 +32,10 @@ for FILE in $STAGED_PY_FILES; do
         echo "  Checking: $FILE"
         
         # Use python -m py_compile to check syntax
-        python3 -m py_compile "$FILE" 2>/dev/null
-        
-        if [ $? -ne 0 ]; then
+        # Use python -m py_compile to check syntax
+        if ! OUTPUT=$(python3 -m py_compile "$FILE" 2>&1); then
             echo "    ❌ Syntax error detected in $FILE!"
-            # Show the actual error
-            python3 -m py_compile "$FILE"
+            echo "$OUTPUT"
             SYNTAX_ERRORS=$((SYNTAX_ERRORS + 1))
         else
             echo "    ✅ Syntax OK"

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# Pre-commit hook to check Python syntax for all staged Python files
+# This prevents committing broken code with syntax errors
+#
+
+echo "Running Python syntax check on staged files..."
+
+# Get list of staged Python files
+STAGED_PY_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep '\.py$')
+
+if [ -z "$STAGED_PY_FILES" ]; then
+    echo "No Python files staged for commit."
+    exit 0
+fi
+
+# Track if any syntax errors are found
+SYNTAX_ERRORS=0
+
+# Check each staged Python file
+for FILE in $STAGED_PY_FILES; do
+    # Only check if file exists (not deleted)
+    if [ -f "$FILE" ]; then
+        echo "  Checking: $FILE"
+        
+        # Use python -m py_compile to check syntax
+        python3 -m py_compile "$FILE" 2>/dev/null
+        
+        if [ $? -ne 0 ]; then
+            echo "    ❌ Syntax error detected in $FILE!"
+            # Show the actual error
+            python3 -m py_compile "$FILE"
+            SYNTAX_ERRORS=$((SYNTAX_ERRORS + 1))
+        else
+            echo "    ✅ Syntax OK"
+        fi
+    fi
+done
+
+if [ $SYNTAX_ERRORS -gt 0 ]; then
+    echo ""
+    echo "ERROR: $SYNTAX_ERRORS file(s) have syntax errors!"
+    echo "Commit aborted. Please fix the syntax errors before committing."
+    exit 1
+fi
+
+echo "All Python files passed syntax check."
+exit 0


### PR DESCRIPTION
- Created pre-commit hook that validates Python syntax using py_compile
- Hook runs on all staged .py files before committing
- Prevents commits with syntax errors and displays helpful error messages
- Added README.md with setup and usage instructions
- Configured git core.hooksPath to use version-controlled hooks