### PR TITLE
Fix hot-reload message loss issue

### DIFF
--- a/hot_reload.py
+++ b/hot_reload.py
@@ -84,11 +84,13 @@ def run_with_reload(watch_path: str, extra_args: list[str] | None = None) -> int
             observer.stop()
             observer.join()
 
-        # Change detected — terminate the running server and restart.
+        # Change detected - terminate the running server and restart.
         print("[hot-reload] Change detected, restarting server…", file=sys.stderr)
         proc.terminate()
         try:
-            proc.wait(timeout=5)
+            # Give more time for graceful shutdown - allow Telegram messages to complete
+            proc.wait(timeout=35)
         except subprocess.TimeoutExpired:
+            print("[hot-reload] Graceful shutdown timed out, force killing...", file=sys.stderr)
             proc.kill()
             proc.wait()

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -232,9 +232,11 @@ async def handle_settings(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             data = json.loads(json_data)
             settings = data.get("settings", [])
             # Keep truncating until it fits
+            truncated = False
             while len(json.dumps(data, indent=2)) > 2900 and settings:
                 settings.pop()
-            data["truncated"] = True
+                truncated = True
+            data["truncated"] = truncated
             data["total_settings"] = len(db.get_all_settings())
             json_data = json.dumps(data, indent=2)
         await update.message.reply_text(f"<pre>{json_data}</pre>", parse_mode="HTML")
@@ -279,16 +281,18 @@ def make_progress_callback(chat, loop):
 
 async def _track_task(coro):
     """Track a coroutine as an active task for graceful shutdown."""
-    task = asyncio.create_task(coro)
+    task = asyncio.current_task()
     _active_tasks.add(task)
     try:
-        await task
+        await coro
     finally:
         _active_tasks.discard(task)
 
 
 async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle incoming text messages."""
+    if _shutdown_event.is_set():
+        return
     # Wrap the actual message handling in a task for tracking
     await _track_task(_handle_message_impl(update, context))
 

--- a/telegram_bot.py
+++ b/telegram_bot.py
@@ -37,6 +37,10 @@ _chat_histories: dict[int, list] = {}
 # Per-chat locks to serialize message processing
 _chat_locks: dict[int, asyncio.Lock] = defaultdict(asyncio.Lock)
 
+# Track active message processing tasks for graceful shutdown
+_active_tasks: set[asyncio.Task] = set()
+_shutdown_event: asyncio.Event = asyncio.Event()
+
 # Server start time for /status
 _start_time: float = 0.0
 
@@ -230,8 +234,8 @@ async def handle_settings(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
             # Keep truncating until it fits
             while len(json.dumps(data, indent=2)) > 2900 and settings:
                 settings.pop()
-                data["truncated"] = True
-                data["total_settings"] = len(db.get_all_settings())
+            data["truncated"] = True
+            data["total_settings"] = len(db.get_all_settings())
             json_data = json.dumps(data, indent=2)
         await update.message.reply_text(f"<pre>{json_data}</pre>", parse_mode="HTML")
 
@@ -273,8 +277,24 @@ def make_progress_callback(chat, loop):
     return callback
 
 
+async def _track_task(coro):
+    """Track a coroutine as an active task for graceful shutdown."""
+    task = asyncio.create_task(coro)
+    _active_tasks.add(task)
+    try:
+        await task
+    finally:
+        _active_tasks.discard(task)
+
+
 async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     """Handle incoming text messages."""
+    # Wrap the actual message handling in a task for tracking
+    await _track_task(_handle_message_impl(update, context))
+
+
+async def _handle_message_impl(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Actual implementation of message handling."""
     chat_id = update.effective_chat.id
     lock = _chat_locks[chat_id]
 
@@ -529,7 +549,22 @@ async def _run_server(
 
     await shutdown_event.wait()
 
-    logger.info("Shutting down\u2026")
+    logger.info("Shutting down...")
+    # Signal shutdown to prevent new tasks
+    _shutdown_event.set()
+
+    # Wait for active message processing tasks to complete (with timeout)
+    if _active_tasks:
+        logger.info(f"Waiting for {len(_active_tasks)} active task(s) to complete...")
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*_active_tasks, return_exceptions=True),
+                timeout=30.0
+            )
+            logger.info("All active tasks completed")
+        except asyncio.TimeoutError:
+            logger.warning("Timeout waiting for tasks to complete, forcing shutdown")
+
     server.stop()
     await tg_app.stop()
     await tg_app.shutdown()


### PR DESCRIPTION
- Track active message processing tasks in telegram_bot.py
- Wait up to 30 seconds for tasks to complete during graceful shutdown
- Increase hot-reload wait timeout from 5s to 35s to allow graceful shutdown
- Add logging for graceful shutdown progress